### PR TITLE
Fix the deprecation warning

### DIFF
--- a/lazy_tweet_embedding.rb
+++ b/lazy_tweet_embedding.rb
@@ -7,7 +7,7 @@ module Jekyll
   class LazyTweetEmbedding
     def get_html(id)
         url = "https://api.twitter.com/1/statuses/oembed.json?id=#{id}"
-        JSON.parse(open(url).read, { :symbolize_names => true })[:html]
+        JSON.parse(URI.open(url).read, { :symbolize_names => true })[:html]
     end
 
     def convert(line)


### PR DESCRIPTION
Use `URI.open` instead of implicit `Kernel.open` to avoid the `warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open` deprecation warning